### PR TITLE
Fixed missing image. Added link to runnable Jupyter Notebook

### DIFF
--- a/content/posts/An-Inquiry-into-Matplotlib-Figures/index.md
+++ b/content/posts/An-Inquiry-into-Matplotlib-Figures/index.md
@@ -25,6 +25,8 @@ import matplotlib.pyplot as plt
 import matplotlib as mpl
 ```
 
+> A Top-Down runnable Jupyter Notebook with the exact contents of this blog can be found [here](https://gist.github.com/akashpalrecha/4652e98c9b2f3f1961637be001dc0239)
+
 > An interactive version of this guide can be accessed on [Google Colab](https://colab.research.google.com/drive/1SOgWPI9HckTQ0zm47Ma-gYCTucMccTxg)
 
 # A word before we get started...
@@ -361,7 +363,7 @@ fig
 
 
 
-![png](output_36_0.png =500)
+![png](output_36_0.png)
 
 
 


### PR DESCRIPTION
- Fixed markdown error that led to an image not being displayed in the published [blog](https://matplotlib.org/matplotblog/posts/an-inquiry-into-matplotlib-figures/).
![Screen Shot 2019-12-28 at 8 49 58 PM](https://user-images.githubusercontent.com/30772842/71545692-41063780-29b4-11ea-8821-038117af30ce.png)

- Added a link to the original GitHub Gist containing a top-down runnable Jupyter [notebook](https://gist.github.com/akashpalrecha/4652e98c9b2f3f1961637be001dc0239).