### PR TITLE
Fix date of RSEF post.

### DIFF
--- a/content/posts/matplotlib-rsef/index.md
+++ b/content/posts/matplotlib-rsef/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Elliott Sales de Andrade hired as Matplotlib Software Research Engineering Fellow"
-date: 2020-03-17T19:51-04:00
+date: 2020-03-20T15:51:00-04:00
 draft: false
 description: "We have hired Elliott Sales de Andrade as the Matplotlib Software Research Engineering Fellow supported by the Chan Zuckerberg Initiative Essential Open Source Software for Science"
 categories: ["News"]


### PR DESCRIPTION
Without the seconds, the timestamp fails to parse, so it's set to 0. I also changed the date/time to today since that's when it went up.