### PR TITLE
Fix link to feed from blog posts

### DIFF
--- a/themes/aether/layouts/partials/nav-bar.html
+++ b/themes/aether/layouts/partials/nav-bar.html
@@ -10,7 +10,7 @@
       {{- $.Site.Title -}}
     {{ end }}
   </a></h1>
-  <a href="index.xml"><img src="/rss.svg" style="width: 25px; margin: 10px" alt="RSS feed"></a>
+  <a href="/matplotblog/index.xml"><img src="/rss.svg" style="width: 25px; margin: 10px" alt="RSS feed"></a>
   <div class="hamburger-menu">
     <button onclick="hamburgerMenuPressed.call(this)" aria-haspopup="true" aria-expanded="false" aria-controls="menu" aria-label="Menu">
       <span></span>


### PR DESCRIPTION
Now, relative to root url.

The feed link in the header also vanishes in blog posts. This needs to be fixed but I am not familiar with Hugo templating:

https://github.com/matplotlib/matplotblog/blob/2ebc5180e1a2cea299429514b8c356f510978ba5/themes/aether/layouts/partials/head.html#L29-L31